### PR TITLE
Remove duplicate warning in Cloud Composer's docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -24,18 +24,19 @@ To get more information about Environments, see:
   * [Configuring Shared VPC for Composer Environments](https://cloud.google.com/composer/docs/composer-2/configure-shared-vpc)
 * [Apache Airflow Documentation](http://airflow.apache.org/)
 
-~> **Warning:** We **STRONGLY** recommend you read the [GCP
+We **STRONGLY** recommend you read the [GCP
 guides](https://cloud.google.com/composer/docs/how-to) as the Environment resource requires a long
 deployment process and involves several layers of GCP infrastructure, including a Kubernetes Engine
 cluster, Cloud Storage, and Compute networking resources. Due to limitations of the API, Terraform
-will not be able to automatically find or manage many of these underlying resources. In particular:
-* It can take up to one hour to create or update an environment resource. In addition, GCP may only
-  detect some errors in configuration when they are used (e.g. ~40-50 minutes into the creation
+will not be able to find or manage many of these underlying resources automatically. In particular:
+* Creating or updating an environment resource can take up to one hour. In addition, GCP may only
+  detect some errors in the configuration when they are used (e.g., ~40-50 minutes into the creation
   process), and is prone to limited error reporting. If you encounter confusing or uninformative
   errors, please verify your configuration is valid against GCP Cloud Composer before filing bugs
-  against the Terraform provider. * **Environments create Google Cloud Storage buckets that do not get
-  cleaned up automatically** on environment deletion. [More about Composer's use of Cloud
-  Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage). * Please review the [known
+  against the Terraform provider.
+* **Environments create Google Cloud Storage buckets that are not automatically cleaned up** on environment deletion. [More about Composer's use of Cloud
+  Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage).
+* Please review the [known
   issues](https://cloud.google.com/composer/docs/known-issues) for Composer if you are having
   problems.
 
@@ -64,29 +65,9 @@ resource "google_composer_environment" "test" {
 
 ### With GKE and Compute Resource Dependencies
 
-**NOTE** To use custom service accounts, you need to give at least `role/composer.worker` to the service account being used by the GKE Nodes on the Composer project.
+**NOTE** To use custom service accounts, you must give at least `role/composer.worker` to the service account used by the GKE Nodes on the Composer project.
 For more information, see the [Access Control](https://cloud.devsite.corp.google.com/composer/docs/how-to/access-control) page in the Cloud Composer documentation.
 You may need to assign additional roles depending on what the Airflow DAGs will be running.
-
-**NOTE** We STRONGLY recommend you read the [Cloud Composer guides](https://cloud.google.com/composer/docs/how-to)
-as the Environment
-resource requires a long deployment process and involves several layers of
-Google Cloud infrastructure, including a Kubernetes Engine cluster, Cloud
-Storage, and Compute networking resources. Composer manages most of these
-resources fully and as a result, Terraform may not be able to automatically
-find or manage the underlying resources. In particular:
-* It can take up to 50 minutes to create or update an environment resource and
-some errors may be detected later in the process. Also, some error messages may
-not be clear at first sight because they involve issues with the underlying
-resources. If you encounter such errors, please review Composer logs and verify
-if your configuration is valid against Cloud Composer before filing bugs
-against the Terraform provider.
-* Environments create Google Cloud Storage buckets that contain your DAGs and
-other work files. These buckets do not get deleted automatically on environment
-deletion. This is by design; it ensures that DAGs source code and other
-valuable data don’t get lost when an environment is deleted. [More about
-Composer's use of Cloud Storage](https://cloud.google.com/composer/docs/concepts/cloud-storage).
-* Please review the [known issues](https://cloud.google.com/composer/docs/known-issues) for Cloud Composer if you are having problems.
 
 #### GKE and Compute Resource Dependencies (Cloud Composer 1)
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
There is a duplicate warning in the Cloud Composer's documentation file. I removed one of them and did some additional proofreading.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
